### PR TITLE
chore: Upgrade release action, correct deb names

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -125,14 +125,10 @@ jobs:
 
           mkdir -p release
           for dir in release-artifacts/linamp-*; do
-            artifact_name=$(basename "$dir")
-            arch=$(echo "$artifact_name" | cut -d'-' -f2)
-            dist=$(echo "$artifact_name" | cut -d'-' -f3)
-
             for deb in "$dir"/*.deb; do
               [ -e "$deb" ] || continue
               deb_name=$(basename "$deb" .deb)
-              cp "$deb" "release/${deb_name}_${dist}_${arch}.deb"
+              cp "$deb" "release/${deb_name}.deb"
             done
           done
 
@@ -145,6 +141,6 @@ jobs:
           ls -la release
 
       - name: Publish GitHub release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release/*.deb


### PR DESCRIPTION
This pull request makes minor improvements to the Debian package build workflow by simplifying artifact naming and updating an action dependency.

- **Build artifact handling:**
  * The naming of `.deb` release artifacts has been simplified to use only the base package name, removing architecture and distribution from the filename, that is already part of the base name. (`.github/workflows/build-deb.yml`)

- **Dependency update:**
  * The workflow now uses version `v3` of `softprops/action-gh-release` instead of `v2` for publishing release assets. (`.github/workflows/build-deb.yml`)